### PR TITLE
improve the util for operation of create/update 

### DIFF
--- a/huaweicloud/elb_utils.go
+++ b/huaweicloud/elb_utils.go
@@ -115,19 +115,38 @@ func isELBResourceNotFound(err error) bool {
 	return ok
 }
 
+// The result may be not correct when the type of param is string and user config it to 'param=""'
+// but, there is no other way.
 func hasFilledParam(d *schema.ResourceData, param string) bool {
 	_, b := d.GetOkExists(param)
 	return b
 }
 
-type skipParamParsing func(tags []string) bool
+func getParamTag(key string, tag reflect.StructTag) string {
+	v, ok := tag.Lookup(key)
+	if ok {
+		return v
+	}
+	return "tag_not_set"
+}
+
+type skipParamParsing func(jsonTags []string, tag reflect.StructTag) bool
 
 func buildELBCreateParam(opts interface{}, d *schema.ResourceData) (error, []string) {
 	var not_pass_params []string
 	var h skipParamParsing
-	h = func(tags []string) bool {
-		param := tags[0]
-		if len(tags) == 1 || tags[1] == "-" && !hasFilledParam(d, param) {
+	h = func(jsonTags []string, tag reflect.StructTag) bool {
+		if getParamTag("required", tag) == "true" {
+			return false
+		}
+
+		param := jsonTags[0]
+		// For Create operation, it should not pass the parameter in the request, which match all the following situations.
+		// a. Parameter is optional, which means it is not set 'required' in the tag.
+		// b. Parameter's default value is allowed, which menas it is not set 'omitempty' in the tag of 'json'. The default value is like this, '0' for int and 'false' for bool
+		// c. Parameter is not set default value in schema. It did not find a way to check whether it was set default value in the schema. so, add a new tag of "no_default" to mark it.
+		// d. User did not set that parameter in the configuration file, which means the return value of 'hasFilledParam' is false.
+		if (len(jsonTags) == 1 || jsonTags[1] == "-") && getParamTag("no_default", tag) == "y" && !hasFilledParam(d, param) {
 			not_pass_params = append(not_pass_params, param)
 			return true
 		}
@@ -143,9 +162,10 @@ func buildELBUpdateParam(opts interface{}, d *schema.ResourceData) (error, []str
 	var not_pass_params []string
 
 	var h skipParamParsing
-	h = func(tags []string) bool {
-		param := tags[0]
+	h = func(jsonTags []string, tag reflect.StructTag) bool {
+		param := jsonTags[0]
 
+		// filter the unchanged parameters
 		if !d.HasChange(param) {
 			not_pass_params = append(not_pass_params, param)
 			return true
@@ -181,12 +201,12 @@ func buildELBCUParam(opts interface{}, d *schema.ResourceData, skip skipParamPar
 	for i := 0; i < optsValue.NumField(); i++ {
 		v := optsValue.Field(i)
 		f := optsType.Field(i)
-		tag := f.Tag.Get("json")
+		tag := getParamTag("json", f.Tag)
 		if tag == "" {
 			return fmt.Errorf("can not convert for item %v: without of json tag", v)
 		}
 		tags := strings.Split(tag, ",")
-		if skip(tags) {
+		if skip(tags, f.Tag) {
 			continue
 		}
 		param := tags[0]

--- a/huaweicloud/resource_huaweicloud_elb_backendecs.go
+++ b/huaweicloud/resource_huaweicloud_elb_backendecs.go
@@ -99,7 +99,7 @@ func resourceELBBackendECSCreate(d *schema.ResourceData, meta interface{}) error
 	}
 
 	var createOpts backendecs.CreateOpts
-	err = buildELBCreateParam(&createOpts, d)
+	err, _ = buildELBCreateParam(&createOpts, d)
 	if err != nil {
 		return fmt.Errorf("Error creating %s: building parameter failed:%s", nameELBBackend, err)
 	}

--- a/huaweicloud/resource_huaweicloud_elb_healthcheck.go
+++ b/huaweicloud/resource_huaweicloud_elb_healthcheck.go
@@ -149,7 +149,7 @@ func resourceELBHealthCheckCreate(d *schema.ResourceData, meta interface{}) erro
 	}
 
 	var createOpts healthcheck.CreateOpts
-	err = buildELBCreateParam(&createOpts, d)
+	err, _ = buildELBCreateParam(&createOpts, d)
 	if err != nil {
 		return fmt.Errorf("Error creating %s: building parameter failed:%s", nameELBHC, err)
 	}
@@ -193,7 +193,7 @@ func resourceELBHealthCheckUpdate(d *schema.ResourceData, meta interface{}) erro
 	hcId := d.Id()
 
 	var updateOpts healthcheck.UpdateOpts
-	err = buildELBUpdateParam(&updateOpts, d)
+	err, _ = buildELBUpdateParam(&updateOpts, d)
 	if err != nil {
 		return fmt.Errorf("Error updating %s(%s): building parameter failed:%s", nameELBHC, hcId, err)
 	}

--- a/huaweicloud/resource_huaweicloud_elb_listener.go
+++ b/huaweicloud/resource_huaweicloud_elb_listener.go
@@ -292,7 +292,7 @@ func resourceELBListenerCreate(d *schema.ResourceData, meta interface{}) error {
 	}
 
 	var opts listeners.CreateOpts
-	err = buildELBCreateParam(&opts, d)
+	err, _ = buildELBCreateParam(&opts, d)
 	if err != nil {
 		return fmt.Errorf("Error creating %s: building parameter failed:%s", nameELBListener, err)
 	}
@@ -351,7 +351,7 @@ func resourceELBListenerUpdate(d *schema.ResourceData, meta interface{}) error {
 	lId := d.Id()
 
 	var opts listeners.UpdateOpts
-	err = buildELBUpdateParam(&opts, d)
+	err, _ = buildELBUpdateParam(&opts, d)
 	if err != nil {
 		return fmt.Errorf("Error updating %s %s: building parameter failed:%s", nameELBListener, lId, err)
 	}

--- a/huaweicloud/resource_huaweicloud_elb_loadbalancer.go
+++ b/huaweicloud/resource_huaweicloud_elb_loadbalancer.go
@@ -170,7 +170,7 @@ func resourceELBLoadBalancerCreate(d *schema.ResourceData, meta interface{}) err
 	}
 
 	var opts loadbalancers.CreateOpts
-	err = buildELBCreateParam(&opts, d)
+	err, _ = buildELBCreateParam(&opts, d)
 	if err != nil {
 		return fmt.Errorf("Error creating %s: building parameter failed:%s", nameELBLB, err)
 	}
@@ -259,7 +259,7 @@ func resourceELBLoadBalancerUpdate(d *schema.ResourceData, meta interface{}) err
 	lbId := d.Id()
 
 	var updateOpts loadbalancers.UpdateOpts
-	err = buildELBUpdateParam(&updateOpts, d)
+	err, _ = buildELBUpdateParam(&updateOpts, d)
 	if err != nil {
 		return fmt.Errorf("Error updating %s %s: building parameter failed:%s", nameELBLB, lbId, err)
 	}


### PR DESCRIPTION
This PR revises two situations.
1. For Create operation, it should not pass the parameter in the request, which match all the following situations.
  a. Parameter is optional
  b. Parameter's default value  is allowed, for example, to int, it is 0, to bool, it is false,
  c. Parameter is not set default value in schema
  d. User did not set that parameter in the  configuration file.

2. For Update operation, it should only pass the changed parameters to the request.
